### PR TITLE
Make confirm_message and rmdiacritics easier to use

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="tsutils",
-    version="3.2.2",
+    version="3.2.3",
     author="The Tsubotki Team",
     author_email="69992611+TsubakiBotPad@users.noreply.github.com",
     license="MIT",

--- a/tsutils/formatting.py
+++ b/tsutils/formatting.py
@@ -53,9 +53,9 @@ def rmdiacritics(string):
             if cutoff != -1:
                 desc = desc[:cutoff]
             output += unicodedata.lookup(desc)
-        except KeyError:
+        except (KeyError, ValueError):
             output += c
-    return output
+    return re.sub("[\u201c\u201d]", '"', output)
 
 
 def clean_global_mentions(content):

--- a/tsutils/user_interaction.py
+++ b/tsutils/user_interaction.py
@@ -18,8 +18,8 @@ async def send_repeated_consecutive_messages(ctx, message):
 
 async def confirm_message(ctx, text, yemoji="✅", nemoji="❌", timeout=10):
     msg = await ctx.send(text)
-    await msg.add_reaction(yemoji)
-    await msg.add_reaction(nemoji)
+    asyncio.create_task(msg.add_reaction(yemoji))
+    asyncio.create_task(msg.add_reaction(nemoji))
 
     def check(reaction, user):
         return (str(reaction.emoji) in [yemoji, nemoji]
@@ -44,7 +44,7 @@ async def get_reaction(ctx, text, *emoji, timeout=10):
     async def addreactions():
         for e in emoji:
             try:
-                await msg.add_reaction(e)
+                asyncio.create_task(msg.add_reaction(e))
             except (discord.Forbidden, discord.NotFound):
                 pass
 


### PR DESCRIPTION
The change in confirm_message makes it so it isn't necessary to wait for all of the reactions to load before reacting.  The change to rmdiacritics make it not crash on a newline, and also turns fancy quotes into normal ones.