### PR TITLE
Use a safer enum object

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="tsutils",
-    version="3.3.8",
+    version="3.3.9",
     author="The Tsubotki Team",
     author_email="69992611+TsubakiBotPad@users.noreply.github.com",
     license="MIT",

--- a/tsutils/enums.py
+++ b/tsutils/enums.py
@@ -1,23 +1,32 @@
 from enum import Enum
 
-class Server(Enum):
+
+class SmartEqEnum(Enum):
+    def __eq__(self, other):
+        if isinstance(other, Enum):
+            return self.name == other.name \
+                   and self.value == other.value \
+                   and self.__class__.__name__ == other.__class__.__name__
+        return False
+
+class Server(SmartEqEnum):
     COMBINED = "COMBINED"
     JP = "JP"
     NA = "NA"
     KR = "KR"
 
 
-class EvoToFocus(Enum):
+class EvoToFocus(SmartEqEnum):
     newest = 0
     naprio = 1
 
 
-class AltEvoSort(Enum):
+class AltEvoSort(SmartEqEnum):
     dfs = 0
     numerical = 1
 
 
-class ChildMenuSelector(Enum):
+class ChildMenuSelector(SmartEqEnum):
     IdMenu = 0
     NaDiffMenu = 1
     AwakeningList = 2


### PR DESCRIPTION
This allows enums to be equal to each other even when they're not imported the same way.  This is great for Red bc importing anything sucks always